### PR TITLE
Use mktemp to source a randomly named, temporary file.

### DIFF
--- a/lock
+++ b/lock
@@ -2,7 +2,7 @@
 
 # Dependencies: imagemagick, i3lock-color-git, scrot
 
-IMAGE=/tmp/i3lock.png
+IMAGE=$(mktemp).png
 
 VALUE="60" #brightness value to compare to
 scrot $IMAGE


### PR DESCRIPTION
In multiuser situation we can see two users try to read/write to the same file.

Plus, you can try to troll someone by placing a prepared image in /tmp and take away writing rights. The script will use it.