### PR TITLE
Avoid repeating i3lock call by turning parameter list into variable.

### DIFF
--- a/lock
+++ b/lock
@@ -9,6 +9,7 @@ TEXT="Type password to unlock"
 case $LANG in
     fr_* ) TEXT="Entrez votre mot de passe" ;; # Français
     es_* ) TEXT="Ingrese su contraseña" ;; # Española
+    pl_* ) TEXT="Podaj hasło" ;; # Polish
 esac
 
 

--- a/lock
+++ b/lock
@@ -21,10 +21,18 @@ COLOR=`convert $IMAGE -colorspace hsb -resize 1x1 txt:- | sed -E '/.*$/ {
 
 if [ "$COLOR" -gt "$VALUE" ]; then #white background image and black text
     convert $IMAGE -level 0%,100%,0.6 -filter Gaussian -resize 30% -define filter:sigma=2.5 -resize 333.33% -font Liberation-Sans -pointsize 26 -fill black -gravity center -annotate +0+160 "$TEXT" - | composite -gravity center lockdark.png - $IMAGE
-    i3lock --textcolor=00000000 --insidecolor=0000001c --ringcolor=0000003e --linecolor=00000000 --keyhlcolor=ffffff80 --ringvercolor=ffffff00 --insidevercolor=ffffff1c --ringwrongcolor=ffffff55 --insidewrongcolor=ffffff1c  -i $IMAGE
+    PARAM='--textcolor=00000000 --insidecolor=0000001c --ringcolor=0000003e --linecolor=00000000 --keyhlcolor=ffffff80 --ringvercolor=ffffff00 --insidevercolor=ffffff1c --ringwrongcolor=ffffff55 --insidewrongcolor=ffffff1c'
 else #black
     convert $IMAGE -level 0%,100%,0.6 -filter Gaussian -resize 30% -define filter:sigma=2.5 -resize 333.33% -font Liberation-Sans -pointsize 26 -fill white -gravity center -annotate +0+160 "$TEXT" - | composite -gravity center lock.png - $IMAGE
-    i3lock --textcolor=ffffff00 --insidecolor=ffffff1c --ringcolor=ffffff3e --linecolor=ffffff00 --keyhlcolor=00000080 --ringvercolor=00000000 --insidevercolor=0000001c --ringwrongcolor=00000055 --insidewrongcolor=0000001c  -i $IMAGE
+    PARAM='--textcolor=ffffff00 --insidecolor=ffffff1c --ringcolor=ffffff3e --linecolor=ffffff00 --keyhlcolor=00000080 --ringvercolor=00000000 --insidevercolor=0000001c --ringwrongcolor=00000055 --insidewrongcolor=0000001c'
+fi
+
+# try to use a forked version of i3lock with prepared parameters
+i3lock $PARAM -i $IMAGE > /dev/null 2>&1
+
+if [ $? -ne 0 ]; then
+    # We have failed, lets get back to stock one
+    i3lock -i $IMAGE
 fi
 
 rm $IMAGE


### PR DESCRIPTION
Additionally: support for systems running stock i3lock that can't handle colour parameters.

I had no way of testing if i3lock will handle $PARAM correctly because… I don't have the forked version. ;-)