### PR TITLE
Use an exit trap

### DIFF
--- a/lock
+++ b/lock
@@ -15,7 +15,7 @@ OPTIONS="Options:
     -f <fontname>, --font <fontname>  Set a custom font. Type 'convert -list font' in a terminal to get a list."
 
 set -o errexit -o noclobber -o nounset -o pipefail
-trap 'rm -f "$IMAGE"'
+trap 'rm -f "$IMAGE"' EXIT
 TEMP="$(getopt -o :hpgf: -l help,pixelate,greyscale,font: --name "$0" -- "$@")"
 eval set -- "$TEMP"
 

--- a/lock
+++ b/lock
@@ -15,6 +15,7 @@ OPTIONS="Options:
     -f <fontname>, --font <fontname>  Set a custom font. Type 'convert -list font' in a terminal to get a list."
 
 set -o errexit -o noclobber -o nounset -o pipefail
+trap 'rm -f "$IMAGE"'
 TEMP="$(getopt -o :hpgf: -l help,pixelate,greyscale,font: --name "$0" -- "$@")"
 eval set -- "$TEMP"
 


### PR DESCRIPTION
If the script exits due to some error, the rm at the end isn't run, and we're stuck with the created temporary file. Use a trap instead. Also use rm -f to avoid any confirmations.

http://mywiki.wooledge.org/SignalTrap