### PR TITLE
Use realpath instead of dirname

### DIFF
--- a/lock
+++ b/lock
@@ -38,9 +38,8 @@ while true ; do
 done
 
 # get path where the script is located to find the lock icon
-pushd $(dirname $0) > /dev/null
-SCRIPTPATH=$(pwd)
-popd > /dev/null
+SCRIPTPATH=$(realpath "$0")
+SCRIPTPATH=${SCRIPTPATH%/*}
 
 # l10n support
 TEXT="Type password to unlock"


### PR DESCRIPTION
The previous code didn't follow symbolic links. Using $0 is still unreliable though.

Fixes #24