### PR TITLE
Fixes bug with $LANG by creating default case

### DIFF
--- a/lock
+++ b/lock
@@ -57,7 +57,7 @@ case "$LANG" in
     fr_* ) TEXT="Entrez votre mot de passe" ;; # Français
     pl_* ) TEXT="Podaj hasło" ;; # Polish
     it_* ) TEXT="Inserisci la password" ;; # Italian
-    * ) TEXT="Type password to unlock" ;; # Default to English if locale is not one of the previous
+    * ) TEXT="Type password to unlock" ;; # Default to English
 esac
 
 VALUE="60" #brightness value to compare to

--- a/lock
+++ b/lock
@@ -57,6 +57,7 @@ case "$LANG" in
     fr_* ) TEXT="Entrez votre mot de passe" ;; # Français
     pl_* ) TEXT="Podaj hasło" ;; # Polish
     it_* ) TEXT="Inserisci la password" ;; # Italian
+    * ) TEXT="Type password to unlock" ;; # Default to English if locale is not one of the previous
 esac
 
 VALUE="60" #brightness value to compare to


### PR DESCRIPTION
Previously, $LANG could return things such as "C" and not be caught by the case statement and cause an error.  A default case was added to catch these situations and default the text to English.  This resolves #48. 