### PR TITLE
use mogrify instead if convert

### DIFF
--- a/lock
+++ b/lock
@@ -104,8 +104,8 @@ else #black
         --ringwrongcolor=00000055 --insidewrongcolor=0000001c)
 fi
 
-convert "$IMAGE" "${HUE[@]}" "${EFFECT[@]}" -font "$FONT" -pointsize 26 -fill "$BW" -gravity center \
-    -annotate +0+160 "$TEXT" "$ICON" -gravity center -composite "$IMAGE"
+mogrify "$IMAGE" "${HUE[@]}" "${EFFECT[@]}" -font "$FONT" -pointsize 26 -fill "$BW" -gravity center \
+    -annotate +0+160 "$TEXT" "$ICON" -gravity center -composite
 
 # If invoked with -d/--desktop, we'll attempt to minimize all windows (ie. show
 # the desktop) before locking.


### PR DESCRIPTION
mogrify manpage: "Mogrify overwrites the original  image  file, whereas, convert(1) writes to a different image file."
This should be faster.