### PR TITLE
local: $LANG can be actually not set.

### DIFF
--- a/lock
+++ b/lock
@@ -41,7 +41,7 @@ eval set -- "$TEMP"
 
 # l10n support
 TEXT="Type password to unlock"
-case "$LANG" in
+case "${LANG:-}" in
     de_* ) TEXT="Bitte Passwort eingeben" ;; # Deutsch
     da_* ) TEXT="Indtast adgangskode" ;; # Danish
     en_* ) TEXT="Type password to unlock" ;; # English


### PR DESCRIPTION
./lock: line 44: LANG: unbound variable

$LANG is not guaranteed to be set, this change makes lock actually work in such case.
