### PR TITLE
doc: add lock manapge

### DIFF
--- a/doc/lock.1
+++ b/doc/lock.1
@@ -1,0 +1,63 @@
+.TH LOCK 1 2017-06-26
+
+.SH NAME
+.B lock
+- Bash script around i3lock for fancy effect
+
+.SH DESCRIPTION
+
+Takes a screenshot of the desktop, blurs the background and adds a lock icon and
+text.
+
+.SH SYNOPSIS
+
+.B lock [options]
+
+.SH OPTIONS
+
+.TP
+\fB-h, --help\fP
+This help menu.
+
+.TP
+\fB-d, --desktop\fP
+Attempt to minimize all windows before locking.
+
+.TP
+\fB-g, --greyscale\fP
+Set background to greyscale instead of color.
+
+.TP
+\fB-p, --pixelate\fP
+Pixelate the background instead of blur, runs faster.
+
+.TP
+\fB-f <fontname>, --font <fontname>\fP
+Set a custom font.
+
+.TP
+\fB-t <text>, --text <text>\fP
+Set a custom text prompt.
+
+.TP
+\fB-l, --listfonts\fP
+Display a list of possible fonts for use with -f/--font.
+
+.IP
+Note: this option will not lock the screen, it displays the list and exits
+immediately.
+
+.TP
+\fB-n, --nofork\fP
+Do not fork i3lock after starting.
+
+.TP
+\fB--\fP
+Must be last option. Set command to use for taking a screenshot. Default is
+\'import -window root\'. Using \'scrot\' or \'maim\' will increase script speed and
+allow setting custom flags like having a delay.
+
+.SH AUTHORS
+
+Dolores Portalatin <admin@doloresportalatin.info>
+


### PR DESCRIPTION
Hi,

I'm writing a debian [package][deb-pkg] for this. You'll notice I use the dualmonitor branch since otherwise it's hardly "fancy". The package is currently being reviewed by a DD. I wrote a manpage for the package, then I decided to upload it to upstream since it's best practice.

Please consider changing the name of your bash script to `i3lock-fancy` as this is the name I use in the debian package. I'm sure that we can agree that `lock` is not really a shippable script name.

Regards,

[deb-pkg]: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=866177
