### PR TITLE
Proper multimonitor support (2nd try)

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,8 +87,4 @@ Systemd Unit file example (edit for your own use):
 
 Multiple Monitors
 -----------------
-There is a branch called dual monitor with support for multiple monitors. This
-branch uses a grey icon and text with outlines to make it visible on light and
-dark backgrounds (though it looks better on dark backgrounds). I am still
-working to get it looking just right right. The script is usable now, but it's
-under developement and things may change.
+This script fully supports multiple monitors. The lock and text are drawn on the center of each monitor.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Dependencies
 * imagemagick
 * bash
 * awk
-* utils-linux
+* util-linux
 
 Optional Dependencies
 ---------------------

--- a/doc/lock.1
+++ b/doc/lock.1
@@ -7,7 +7,8 @@
 .SH DESCRIPTION
 
 Takes a screenshot of the desktop, blurs the background and adds a lock icon and
-text.
+text. This blurred image is then given to \fBi3lock\fR as the lockscreen
+background.
 
 .SH SYNOPSIS
 

--- a/doc/lock.1
+++ b/doc/lock.1
@@ -59,5 +59,5 @@ allow setting custom flags like having a delay.
 
 .SH AUTHORS
 
-Dolores Portalatin <admin@doloresportalatin.info>
+Dolores Portalatin <hello@doloresportalatin.info>
 

--- a/doc/lock.1
+++ b/doc/lock.1
@@ -57,6 +57,9 @@ Must be last option. Set command to use for taking a screenshot. Default is
 \'import -window root\'. Using \'scrot\' or \'maim\' will increase script speed and
 allow setting custom flags like having a delay.
 
+.SH SEE ALSO
+\fBi3lock\fR(1)
+
 .SH AUTHORS
 
 Dolores Portalatin <hello@doloresportalatin.info>

--- a/doc/lock.1
+++ b/doc/lock.1
@@ -1,0 +1,63 @@
+.TH LOCK 1 2017-06-26
+
+.SH NAME
+.B lock
+- Bash script around i3lock for fancy effect
+
+.SH DESCRIPTION
+
+Takes a screenshot of the desktop, blurs the background and adds a lock icon and
+text.
+
+.SH SYNOPSIS
+
+.B lock [options]
+
+.SH OPTIONS
+
+.TP
+\fB-h, --help\fP
+This help menu.
+
+.TP
+\fB-d, --desktop\fP
+Attempt to minimize all windows before locking.
+
+.TP
+\fB-g, --greyscale\fP
+Set background to greyscale instead of color.
+
+.TP
+\fB-p, --pixelate\fP
+Pixelate the background instead of blur, runs faster.
+
+.TP
+\fB-f <fontname>, --font <fontname>\fP
+Set a custom font.
+
+.TP
+\fB-t <text>, --text <text>\fP
+Set a custom text prompt.
+
+.TP
+\fB-l, --listfonts\fP
+Display a list of possible fonts for use with -f/--font.
+
+.IP
+Note: this option will not lock the screen, it displays the list and exits
+immediately.
+
+.TP
+\fB-n, --nofork\fP
+Do not fork i3lock after starting.
+
+.TP
+\fB--\fP
+Must be last option. Set command to use for taking a screenshot. Default is
+\'import -window root\'. Using \'scrot\' or \'maim\' will increase script speed and
+allow setting custom flags like having a delay.
+
+.SH AUTHORS
+
+Dolores Portalatin <admin@doloresportalatin.info>
+

--- a/doc/lock.1
+++ b/doc/lock.1
@@ -17,7 +17,7 @@ text.
 
 .TP
 \fB-h, --help\fP
-This help menu.
+Display a help screen and exit.
 
 .TP
 \fB-d, --desktop\fP

--- a/lock
+++ b/lock
@@ -122,7 +122,7 @@ options="Options:
 
 # move pipefail down as for some reason "convert -list font" returns 1
 set -o pipefail
-trap 'rm -rf "$image"' EXIT
+trap 'rm -f "$image"' EXIT
 temp="$(getopt -o :hdnpglt:f: -l desktop,help,listfonts,nofork,pixelate,greyscale,text:,font: --name "$0" -- "$@")"
 eval set -- "$temp"
 

--- a/lock
+++ b/lock
@@ -123,6 +123,7 @@ options="Options:
 # move pipefail down as for some reason "convert -list font" returns 1
 set -o pipefail
 trap 'rm -f "$image"' EXIT
+trap 'rm -rf "$wd"' EXIT
 temp="$(getopt -o :hdnpglt:f: -l desktop,help,listfonts,nofork,pixelate,greyscale,text:,font: --name "$0" -- "$@")"
 eval set -- "$temp"
 

--- a/lock
+++ b/lock
@@ -18,25 +18,37 @@ get_text_width() {
     convert "${text_options[@]}" label:"$1" -format "%[fx:w]\n" info:
 }
 
-# Applies the effects, the lock image and the text to the given monitor
-# Crops the screenshot to only the given monitor and performs all operation on that image
-# The images for all the monitors are later stitched together
+# Calculates the absolute positions for the lock and text or the given monitor, generates the command line arguemnts
+# for convert that apply the lock icon and the text to the proper locations and adds them to the decorations_params array
 # $1 - Monitor Width
 # $2 - Monitor Height
 # $3 - X Offset
 # $4 - Y Offset
-# Prints the brigthness in the center of the monitor to stdout
+# Prints the brigthness in the center of the monitor to file descriptor 3
 # This is used to determine the average brightness in the centers of all the monitors and to then set the proper colors
 # for i3lock-color
 process_monitor() {
-    # Store the offset information directly in the filename
-    file="$wd/MON+$3+$4.png"
+    width=$1
+    height=$2
+    x_offset=$3
+    y_offset=$4
 
-    # Extract only the screenshot for the current monitor
-    convert "$image" -crop "$1x$2+$3+$4" "$file"
+    # center coordinates relative to the current monitor
+    x_mid=$((width / 2))
+    y_mid=$((height / 2))
+
+    # absolute X, Y coordinates of the top left edge of the text
+    x_text=$((x_offset + x_mid - (text_width / 2)))
+    y_text=$((y_offset + y_mid + 160))
+
+    # absolute X, Y coordinates of the top left edge of the icon
+    # The lock icon has dimensions 60x60, we subtract half of that from each dimension
+    # If the lock dimensions ever change, these values here need to be changed too
+    x_icon=$((x_offset + x_mid - 30))
+    y_icon=$((y_offset + y_mid - 30))
 
     # Get brightness for the middle of the monitor
-    brightness="$(get_brightness "$file" "-gravity Center -crop 100x100+0+0")"
+    brightness="$(get_brightness "$image" "-crop 100x100+$x_icon+$y_icon")"
 
     if [ "$brightness" -gt "$threshold" ]; then # bright background image and black text
         text_color="black"
@@ -46,11 +58,10 @@ process_monitor() {
         icon="$scriptpath/icons/lock.png"
     fi
 
-    # Apply everything to the image containing only the screenshot of the given monitor
-    convert "$file" +repage "${text_options[@]}" -fill "$text_color" -gravity Center -annotate +0+160 "$text" \
-        "$icon" -gravity Center -composite "$file"
+    decoration_params+=(+repage "${text_options[@]}" -fill "$text_color" -annotate "+$x_text+$y_text" "$text" "$icon" -geometry "+$x_icon+$y_icon" -composite)
 
-    echo "$brightness"
+    # Write brightness to file descriptor
+    exec 3<<< "$brightness"
 }
 
 # get path where the script is located to find the lock icon
@@ -153,7 +164,9 @@ cd "$wd" || exit 1
 
 command -- "${shot[@]}" "$image"
 
-convert "$image" "${hue[@]}" "${effect[@]}" "$image"
+# All the arguments to be passed to convert, to add the lock and text to the monitors is collected here so that we can
+# apply them in a single call to convert
+decoration_params=()
 
 # We collect the brightness values from all the monitors and average them, from that we determine which flags to pass to
 # i3lock-color since the colors for i3lock-color cannot be specified per monitor. 
@@ -163,7 +176,7 @@ sum_brightness=0
 num_monitors=0
 
 # Loop through all connected monitors (as reported by xrandr)
-# For each monitor its section in the screenshot is extracted and processed
+# For each monitor the convert arguments to add the lock and text to that monitor are generated
 while read -r monitor; do
     if [[ "$monitor" =~ ([0-9]+)x([0-9]+)\+([0-9]+)\+([0-9]+) ]]; then
         width=${BASH_REMATCH[1]}
@@ -171,13 +184,19 @@ while read -r monitor; do
         x_offset=${BASH_REMATCH[3]}
         y_offset=${BASH_REMATCH[4]}
 
-        # TODO fork
-        brightness=$(process_monitor "$width" "$height" "$x_offset" "$y_offset")
+        # We get the return value from the function by using a new file descriptor
+        # The traditional approach of using $(process_monitor ...) and echo doesn't work because it forks into a 
+        # subshell and then process_monitor cannot access decoration_params
+        exec 3>&-
+        process_monitor "$width" "$height" "$x_offset" "$y_offset" && read -r brightness <&3
+        exec 3>&-
 
         sum_brightness=$((brightness + sum_brightness))
         num_monitors=$((num_monitors + 1))
     fi
 done <<<"$(xrandr --verbose | grep "\bconnected\b")"
+
+convert "$image" "${hue[@]}" "${effect[@]}" "${decoration_params[@]}" "$image"
 
 avg_brightness=$((sum_brightness / num_monitors))
 
@@ -192,19 +211,6 @@ else # Bright colors
         "--separatorcolor=22222260" "--insidevercolor=0000001c" \
         "--ringwrongcolor=00000055" "--insidewrongcolor=0000001c")
 fi
-
-stitch_params=()
-
-for f in MON*.png; do
-    # The offset information for the monitors is stored directly in the filename so we don't have 
-    # to map the offsets to the filenames
-    offset=${f%.*}
-    offset=${offset:3}
-    stitch_params+=("-page" "$offset" "$f")
-done
-
-# Merge the screenshots of the individual monitors back together into one big image
-convert "${stitch_params[@]}" -background transparent -layers merge "$image"
 
 # If invoked with -d/--desktop, we'll attempt to minimize all windows (ie. show
 # the desktop) before locking.

--- a/lock
+++ b/lock
@@ -89,7 +89,7 @@ font=$(convert -list font | awk "{ a[NR] = \$2 } /family: $(fc-match sans -f "%{
 image="$(mktemp --suffix=.png)"
 
 # brightness value to compare to, everything above is considered white and everything below black
-threshold="60" 
+threshold="40" 
 
 desktop=""
 shot=(import -window root)

--- a/lock
+++ b/lock
@@ -122,7 +122,7 @@ options="Options:
 
 # move pipefail down as for some reason "convert -list font" returns 1
 set -o pipefail
-trap 'rm -rf "$wd"' EXIT
+trap 'rm -rf "$image"' EXIT
 temp="$(getopt -o :hdnpglt:f: -l desktop,help,listfonts,nofork,pixelate,greyscale,text:,font: --name "$0" -- "$@")"
 eval set -- "$temp"
 

--- a/lock
+++ b/lock
@@ -15,6 +15,11 @@ get_brightness() {
 # $1 - The text to checked
 # Prints the text width in pixels to stdout
 get_text_width() {
+    # empty text or text containing only whitespace would throw an error so we just return zero
+    if [ -z "${1// }" ]; then
+        echo 0
+        return
+    fi
     convert "${text_options[@]}" label:"$1" -format "%[fx:w]\n" info:
 }
 
@@ -58,7 +63,15 @@ process_monitor() {
         icon="$scriptpath/icons/lock.png"
     fi
 
-    decoration_params+=(+repage "${text_options[@]}" -fill "$text_color" -annotate "+$x_text+$y_text" "$text" "$icon" -geometry "+$x_icon+$y_icon" -composite)
+    decoration_params+=(+repage)
+
+    if [ "$text_width" -ne 0 ]; then
+        # Only add text flags, if there actually is text
+        decoration_params+=("${text_options[@]}" -fill "$text_color" -annotate "+$x_text+$y_text" "$text")
+    fi
+
+    decoration_params+=("$icon" -geometry "+$x_icon+$y_icon" -composite)
+
 
     # Write brightness to file descriptor
     exec 3<<< "$brightness"

--- a/lock
+++ b/lock
@@ -54,11 +54,16 @@ hue=(-level "0%,100%,0.6")
 effect=(-filter Gaussian -resize 20% -define "filter:sigma=1.5" -resize 500.5%)
 # default system sans-serif font
 font=$(convert -list font | awk "{ a[NR] = \$2 } /family: $(fc-match sans -f "%{family}\n")/ { print a[NR-1]; exit }")
+
+# All the files used will be stored here
 wd="$(mktemp -d)"
-image=$(mktemp).png
-shot=(import -window root)
-threshold="60" #brightness value to compare to, everything above is considered white and everything below black
+image="$wd/shot.png"
+
+# brightness value to compare to, everything above is considered white and everything below black
+threshold="60" 
+
 desktop=""
+shot=(import -window root)
 i3lock_cmd=(i3lock -i "$image")
 shot_custom=false
 
@@ -88,7 +93,6 @@ options="Options:
 
 # move pipefail down as for some reason "convert -list font" returns 1
 set -o pipefail
-trap 'rm -f "$image"' EXIT
 trap 'rm -rf "$wd"' EXIT
 temp="$(getopt -o :hdnpglt:f: -l desktop,help,listfonts,nofork,pixelate,greyscale,text:,font: --name "$0" -- "$@")"
 eval set -- "$temp"

--- a/lock
+++ b/lock
@@ -122,7 +122,6 @@ options="Options:
 
 # move pipefail down as for some reason "convert -list font" returns 1
 set -o pipefail
-trap 'rm -f "$image"' EXIT
 trap 'rm -rf "$wd"' EXIT
 temp="$(getopt -o :hdnpglt:f: -l desktop,help,listfonts,nofork,pixelate,greyscale,text:,font: --name "$0" -- "$@")"
 eval set -- "$temp"

--- a/lock
+++ b/lock
@@ -11,6 +11,13 @@ get_brightness() {
     convert "$1" +repage $2 -colorspace gray -format "%[fx:round(100*mean)]" info:
 }
 
+# Determines the width of the given text when processed using the text_options flag
+# $1 - The text to checked
+# Prints the text width in pixels to stdout
+get_text_width() {
+    convert "${text_options[@]}" label:"$1" -format "%[fx:w]\n" info:
+}
+
 # Applies the effects, the lock image and the text to the given monitor
 # Crops the screenshot to only the given monitor and performs all operation on that image
 # The images for all the monitors are later stitched together
@@ -40,8 +47,8 @@ process_monitor() {
     fi
 
     # Apply everything to the image containing only the screenshot of the given monitor
-    convert "$file" +repage -font "$font" -pointsize 26 -fill "$text_color" -gravity Center \
-        -annotate +0+160 "$text" "$icon" -gravity Center -composite "$file"
+    convert "$file" +repage "${text_options[@]}" -fill "$text_color" -gravity Center -annotate +0+160 "$text" \
+        "$icon" -gravity Center -composite "$file"
 
     echo "$brightness"
 }
@@ -138,6 +145,9 @@ done
 if "$shot_custom" && [[ $# -gt 0 ]]; then
     shot=("$@");
 fi
+
+text_options=(-font "$font" -pointsize 26)
+text_width=$(get_text_width "$text")
 
 cd "$wd" || exit 1
 

--- a/lock
+++ b/lock
@@ -3,6 +3,22 @@
 # Dependencies: imagemagick, i3lock-color-git, scrot, wmctrl (optional)
 set -o errexit -o noclobber -o nounset
 
+# Determines if the screenshot taken is dark in a given area
+# This is used to choose which lock to use and in which color to show the text
+# $1 - See $1 of get_brightness
+# $2 - (between 0 and 100) Threshold value. If a value lower than this is found, the image is dark in the given area
+is_dark() {
+    [ "$(get_brightness "$1")" -gt "$2" ] && return 1 || return 0
+}
+
+# Determines the brightness of the screenshot
+# $1 - Arguments passed to 'convert'. For example this can be used to crop the image, to just sample a part of it
+
+get_brightness() {
+    # Quite fast way of getting a brightness value
+    convert "$image" -gravity Center $1 -colorspace gray -format "%[fx:round(100*mean)]" info:
+}
+
 # get path where the script is located to find the lock icon
 scriptpath=$(readlink -f -- "$0")
 scriptpath=${scriptpath%/*}
@@ -93,10 +109,7 @@ command -- "${shot[@]}" "$image"
 
 value="60" #brightness value to compare to
 
-color=$(convert "$image" -gravity center -crop 100x100+0+0 +repage -colorspace hsb \
-    -resize 1x1 txt:- | awk -F '[%$]' 'NR==2{gsub(",",""); printf "%.0f\n", $(NF-1)}');
-
-if [[ $color -gt $value ]]; then #white background image and black text
+if ! is_dark "-gravity Center -crop 100x100+0+0" "$value"; then #white background image and black text
     bw="black"
     icon="$scriptpath/icons/lockdark.png"
     param=("--textcolor=00000000" "--insidecolor=0000001c" "--ringcolor=0000003e" \

--- a/lock
+++ b/lock
@@ -73,9 +73,7 @@ effect=(-filter Gaussian -resize 20% -define "filter:sigma=1.5" -resize 500.5%)
 # default system sans-serif font
 font=$(convert -list font | awk "{ a[NR] = \$2 } /family: $(fc-match sans -f "%{family}\n")/ { print a[NR-1]; exit }")
 
-# All the files used will be stored here
-wd="$(mktemp -d)"
-image="$wd/shot.png"
+image="$(mktemp --suffix=.png)"
 
 # brightness value to compare to, everything above is considered white and everything below black
 threshold="60" 
@@ -111,7 +109,7 @@ options="Options:
 
 # move pipefail down as for some reason "convert -list font" returns 1
 set -o pipefail
-trap 'rm -rf "$wd"' EXIT
+trap 'rm -rf "$image"' EXIT
 temp="$(getopt -o :hdnpglt:f: -l desktop,help,listfonts,nofork,pixelate,greyscale,text:,font: --name "$0" -- "$@")"
 eval set -- "$temp"
 
@@ -159,8 +157,6 @@ fi
 
 text_options=(-font "$font" -pointsize 26)
 text_width=$(get_text_width "$text")
-
-cd "$wd" || exit 1
 
 command -- "${shot[@]}" "$image"
 

--- a/lock
+++ b/lock
@@ -77,9 +77,9 @@ while true ; do
             esac ;;
         -t|--text) text=$2 ; shift 2 ;;
         -l|--listfonts)
-	    convert -list font | awk -F: '/Font: / { print $2 }' | sort -du | command -- ${PAGER:-less}
-	    exit 0 ;;
-	-n|--nofork) i3lock_cmd+=(--nofork) ; shift ;;
+            convert -list font | awk -F: '/Font: / { print $2 }' | sort -du | command -- ${PAGER:-less}
+            exit 0 ;;
+        -n|--nofork) i3lock_cmd+=(--nofork) ; shift ;;
         --) shift; shot_custom=true; break ;;
         *) echo "error" ; exit 1 ;;
     esac

--- a/lock
+++ b/lock
@@ -3,20 +3,47 @@
 # Dependencies: imagemagick, i3lock-color-git, scrot, wmctrl (optional)
 set -o errexit -o noclobber -o nounset
 
-# Determines if the screenshot taken is dark in a given area
-# This is used to choose which lock to use and in which color to show the text
-# $1 - See $1 of get_brightness
-# $2 - (between 0 and 100) Threshold value. If a value lower than this is found, the image is dark in the given area
-is_dark() {
-    [ "$(get_brightness "$1")" -gt "$2" ] && return 1 || return 0
-}
-
 # Determines the brightness of the screenshot
-# $1 - Arguments passed to 'convert'. For example this can be used to crop the image, to just sample a part of it
-
+# $1 - Image file to check
+# $2 - Arguments passed to 'convert'. For example this can be used to crop the image, to just sample a part of it
 get_brightness() {
     # Quite fast way of getting a brightness value
-    convert "$image" -gravity Center $1 -colorspace gray -format "%[fx:round(100*mean)]" info:
+    convert "$1" +repage $2 -colorspace gray -format "%[fx:round(100*mean)]" info:
+}
+
+# Applies the effects, the lock image and the text to the given monitor
+# Crops the screenshot to only the given monitor and performs all operation on that image
+# The images for all the monitors are later stitched together
+# $1 - Monitor Width
+# $2 - Monitor Height
+# $3 - X Offset
+# $4 - Y Offset
+# Prints the brigthness in the center of the monitor to stdout
+# This is used to determine the average brightness in the centers of all the monitors and to then set the proper colors
+# for i3lock-color
+process_monitor() {
+    # Store the offset information directly in the filename
+    file="$wd/MON+$3+$4.png"
+
+    # Extract only the screenshot for the current monitor
+    convert "$image" -crop "$1x$2+$3+$4" "$file"
+
+    # Get brightness for the middle of the monitor
+    brightness="$(get_brightness "$file" "-gravity Center -crop 100x100+0+0")"
+
+    if [ "$brightness" -gt "$threshold" ]; then # bright background image and black text
+        text_color="black"
+        icon="$scriptpath/icons/lockdark.png"
+    else # dark background image and white text
+        text_color="white"
+        icon="$scriptpath/icons/lock.png"
+    fi
+
+    # Apply everything to the image containing only the screenshot of the given monitor
+    convert "$file" "${hue[@]}" "${effect[@]}" +repage -font "$font" -pointsize 26 -fill "$text_color" -gravity Center \
+        -annotate +0+160 "$text" "$icon" -gravity Center -composite "$file"
+
+    echo "$brightness"
 }
 
 # get path where the script is located to find the lock icon
@@ -27,8 +54,10 @@ hue=(-level "0%,100%,0.6")
 effect=(-filter Gaussian -resize 20% -define "filter:sigma=1.5" -resize 500.5%)
 # default system sans-serif font
 font=$(convert -list font | awk "{ a[NR] = \$2 } /family: $(fc-match sans -f "%{family}\n")/ { print a[NR-1]; exit }")
+wd="$(mktemp -d)"
 image=$(mktemp).png
 shot=(import -window root)
+threshold="60" #brightness value to compare to, everything above is considered white and everything below black
 desktop=""
 i3lock_cmd=(i3lock -i "$image")
 shot_custom=false
@@ -60,6 +89,7 @@ options="Options:
 # move pipefail down as for some reason "convert -list font" returns 1
 set -o pipefail
 trap 'rm -f "$image"' EXIT
+trap 'rm -rf "$wd"' EXIT
 temp="$(getopt -o :hdnpglt:f: -l desktop,help,listfonts,nofork,pixelate,greyscale,text:,font: --name "$0" -- "$@")"
 eval set -- "$temp"
 
@@ -105,28 +135,60 @@ if "$shot_custom" && [[ $# -gt 0 ]]; then
     shot=("$@");
 fi
 
+cd "$wd" || exit 1
+
 command -- "${shot[@]}" "$image"
 
-value="60" #brightness value to compare to
+# We collect the brightness values from all the monitors and average them, from that we determine which flags to pass to
+# i3lock-color since the colors for i3lock-color cannot be specified per monitor. 
+# We could also just call get_brightness on the whole image but process_monitor samples only the center 
+# of the screen where the lock actually is, so we get a better value for the brightness
+sum_brightness=0
+num_monitors=0
 
-if ! is_dark "-gravity Center -crop 100x100+0+0" "$value"; then #white background image and black text
-    bw="black"
-    icon="$scriptpath/icons/lockdark.png"
+# Loop through all connected monitors (as reported by xrandr)
+# For each monitor its section in the screenshot is extracted and processed
+while read -r monitor; do
+    if [[ "$monitor" =~ ([0-9]+)x([0-9]+)\+([0-9]+)\+([0-9]+) ]]; then
+        width=${BASH_REMATCH[1]}
+        height=${BASH_REMATCH[2]}
+        x_offset=${BASH_REMATCH[3]}
+        y_offset=${BASH_REMATCH[4]}
+
+        # TODO fork
+        brightness=$(process_monitor "$width" "$height" "$x_offset" "$y_offset")
+
+        sum_brightness=$((brightness + sum_brightness))
+        num_monitors=$((num_monitors + 1))
+    fi
+done <<<"$(xrandr --verbose | grep "\bconnected\b")"
+
+avg_brightness=$((sum_brightness / num_monitors))
+
+if [ "$avg_brightness" -gt "$threshold" ]; then # Screenshot is rather bright, so we use dark colors
     param=("--textcolor=00000000" "--insidecolor=0000001c" "--ringcolor=0000003e" \
         "--linecolor=00000000" "--keyhlcolor=ffffff80" "--ringvercolor=ffffff00" \
         "--separatorcolor=22222260" "--insidevercolor=ffffff1c" \
         "--ringwrongcolor=ffffff55" "--insidewrongcolor=ffffff1c")
-else #black
-    bw="white"
-    icon="$scriptpath/icons/lock.png"
+else # Bright colors
     param=("--textcolor=ffffff00" "--insidecolor=ffffff1c" "--ringcolor=ffffff3e" \
         "--linecolor=ffffff00" "--keyhlcolor=00000080" "--ringvercolor=00000000" \
         "--separatorcolor=22222260" "--insidevercolor=0000001c" \
         "--ringwrongcolor=00000055" "--insidewrongcolor=0000001c")
 fi
 
-convert "$image" "${hue[@]}" "${effect[@]}" -font "$font" -pointsize 26 -fill "$bw" -gravity center \
-    -annotate +0+160 "$text" "$icon" -gravity center -composite "$image"
+stitch_params=()
+
+for f in MON*.png; do
+    # The offset information for the monitors is stored directly in the filename so we don't have 
+    # to map the offsets to the filenames
+    offset=${f%.*}
+    offset=${offset:3}
+    stitch_params+=("-page" "$offset" "$f")
+done
+
+# Merge the screenshots of the individual monitors back together into one big image
+convert "${stitch_params[@]}" -background transparent -layers merge "$image"
 
 # If invoked with -d/--desktop, we'll attempt to minimize all windows (ie. show
 # the desktop) before locking.

--- a/lock
+++ b/lock
@@ -40,7 +40,7 @@ process_monitor() {
     fi
 
     # Apply everything to the image containing only the screenshot of the given monitor
-    convert "$file" "${hue[@]}" "${effect[@]}" +repage -font "$font" -pointsize 26 -fill "$text_color" -gravity Center \
+    convert "$file" +repage -font "$font" -pointsize 26 -fill "$text_color" -gravity Center \
         -annotate +0+160 "$text" "$icon" -gravity Center -composite "$file"
 
     echo "$brightness"
@@ -142,6 +142,8 @@ fi
 cd "$wd" || exit 1
 
 command -- "${shot[@]}" "$image"
+
+convert "$image" "${hue[@]}" "${effect[@]}" "$image"
 
 # We collect the brightness values from all the monitors and average them, from that we determine which flags to pass to
 # i3lock-color since the colors for i3lock-color cannot be specified per monitor. 


### PR DESCRIPTION
Does brightness detection on a per monitor basis
Averages the brightness of the centers of all monitors to determine the colors
to pass to i3lock (color version)

Calculates the text width to determine the exact position so this should work
with any text

Speed wise, I was quite surprised:
On my desktop (dualmonitor) the old dualmonitor branch takes 4.48 seconds, the
master branch takes 2.5s and the code in this pull-request takes takes 2.9s to
lock

On my laptop (single screen) both this pull-request and the master branch take
1.8s

So the multimonitor functionality does not seem to add that much overhead for
single monitor systems

If this is satisfactory, I think it would solve the problems described in #10 and #70