### PR TITLE
Using mktemp suffix functionality to prevent leaking tmp files

### DIFF
--- a/lock
+++ b/lock
@@ -11,7 +11,7 @@ hue=(-level "0%,100%,0.6")
 effect=(-filter Gaussian -resize 20% -define "filter:sigma=1.5" -resize 500.5%)
 # default system sans-serif font
 font=$(convert -list font | awk "{ a[NR] = \$2 } /family: $(fc-match sans -f "%{family}\n")/ { print a[NR-1]; exit }")
-image=$(mktemp).png
+image=$(mktemp --suffix=.png)
 shot=(import -window root)
 desktop=""
 i3lock_cmd=(i3lock -i "$image")


### PR DESCRIPTION
I opened issue #90 in reference to this. Essentially i3lock-fancy leaks empty temp files that are never cleaned up, this addresses that.

This fix requires at least coreutils 8.5 to be able to use --suffix (which has been released for a number of years)