### PR TITLE
Too bright greyscale backround

### DIFF
--- a/lock
+++ b/lock
@@ -69,7 +69,7 @@ while true ; do
         -h|--help)
             printf "Usage: %s [options]\n\n%s\n\n" "${0##*/}" "$options"; exit 1 ;;
         -d|--desktop) desktop=$(command -V wmctrl) ; shift ;;
-        -g|--greyscale) hue=(-level "0%,100%,0.6" -set colorspace Gray -separate -average) ; shift ;;
+        -g|--greyscale) hue=(-level "0%,100%,0.6" -set colorspace Gray -average) ; shift ;;
         -p|--pixelate) effect=(-scale 10% -scale 1000%) ; shift ;;
         -f|--font)
             case "$2" in


### PR DESCRIPTION
Recently I've noticed that lock screen with `-g` flag looks way too bright. I've narrowed it down to `convert -separate` flag. It looks like the changes happened in Imagemagick between `6.9.9.25` and `7.0.7.13`, didn't bother to dig much deeper.
With recent Imagemagick versions (>7.0.7.13) this can be fixed simply by removing the `-separate` flag.

The issue:
`convert -level "0%,100%,0.6" -set colorspace Gray -separate -average`
* 6.9.9.25 ![https://i.imgur.com/hBKDaAH.png](https://i.imgur.com/hBKDaAH.png)
* 7.0.7.13 ![https://i.imgur.com/HxDOlo5.png](https://i.imgur.com/HxDOlo5.png)