### PR TITLE
added parameter to the pixelation flag to control the amount of pixelation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+
 i3lock-fancy
 ============
 
@@ -40,7 +41,9 @@ Usage
     
         -g, --greyscale  Set background to greyscale instead of color.
     
-        -p, --pixelate   Pixelate the background instead of blur, runs faster.
+        -p, --pixelate[=factor]  Pixelate the background instead of blur, runs faster.
+                                 The factor is the factor by which the backgroud will be
+                                 scaled. Default is 0.1.
     
         -f <fontname>, --font <fontname>  Set a custom font.
     
@@ -57,7 +60,7 @@ Usage
                          or 'maim' will increase script speed and allow setting
                          custom flags like haing a delay.
 
-example: ```lock -gpf Comic-Sans-MS -- scrot -z```
+example: ```lock -gf Comic-Sans-MS --pixelate=0.05 -- scrot -z```
 
 Extras
 ------

--- a/doc/lock.1
+++ b/doc/lock.1
@@ -29,8 +29,9 @@ Attempt to minimize all windows before locking.
 Set background to greyscale instead of color.
 
 .TP
-\fB-p, --pixelate\fP
-Pixelate the background instead of blur, runs faster.
+\fB-p, --pixelate[=factor]\fP
+Pixelate the background instead of blur, runs faster. The factor is the factor by
+which the backgroud will be scaled. Default is 0.1.
 
 .TP
 \fB-f <fontname>, --font <fontname>\fP
@@ -64,4 +65,3 @@ allow setting custom flags like having a delay.
 .SH AUTHORS
 
 Dolores Portalatin <hello@doloresportalatin.info>
-

--- a/lock
+++ b/lock
@@ -24,7 +24,9 @@ options="Options:
 
     -g, --greyscale  Set background to greyscale instead of color.
 
-    -p, --pixelate   Pixelate the background instead of blur, runs faster.
+    -p, --pixelate[=factor]  Pixelate the background instead of blur, runs faster.
+                             The factor is the factor by which the backgroud will be
+                             scaled. Default is 0.1.
 
     -f <fontname>, --font <fontname>  Set a custom font.
 
@@ -44,7 +46,7 @@ options="Options:
 # move pipefail down as for some reason "convert -list font" returns 1
 set -o pipefail
 trap 'rm -f "$image"' EXIT
-temp="$(getopt -o :hdnpglt:f: -l desktop,help,listfonts,nofork,pixelate,greyscale,text:,font: --name "$0" -- "$@")"
+temp="$(getopt -o :hdnpglt:f: -l desktop,help,listfonts,nofork,pixelate::,greyscale,text:,font: --name "$0" -- "$@")"
 eval set -- "$temp"
 
 # l10n support
@@ -70,7 +72,15 @@ while true ; do
             printf "Usage: %s [options]\n\n%s\n\n" "${0##*/}" "$options"; exit 1 ;;
         -d|--desktop) desktop=$(command -V wmctrl) ; shift ;;
         -g|--greyscale) hue=(-level "0%,100%,0.6" -set colorspace Gray -separate -average) ; shift ;;
-        -p|--pixelate) effect=(-scale 10% -scale 1000%) ; shift ;;
+        -p) effect=(-scale 10% -scale 1000%) ; shift ;;
+        --pixelate)
+            case "$2" in
+                "") effect=(-scale 10% -scale 1000%) ; shift 2 ;;
+                *)
+                  scale_down=$(echo "100*$2" | bc)
+                  scale_up=$(echo "100/$2" | bc)
+                  effect=(-scale $scale_down% -scale $scale_up%) ; shift 2 ;;
+            esac ;;
         -f|--font)
             case "$2" in
                 "") shift 2 ;;


### PR DESCRIPTION
I added a parameter to the pixelation flag to be able to customize the amount of pixelation.

I'm not completly content with the code yet, because the introduction of an optional parameter causes some issues:

* The parameter needs to be written as `--pixelate=0.1`. Neither `--pixelate 0.1` nor `--pixelate0.1` does work. This is due to the way `getopt` works.
* The short form cannot have the optional parameter. If I had added an optional parameter to `-p` the currently working syntax `lock -pg` would break.

I thought about adding another flag with a required parameter instead, but I don't believe it is a good idea to add a _second_ pixelation parameter.

A second issue is that the image resizing used for pixelation does introduce rounding errors in the image size (that means the _converted_ image will not have the same resolution as the input image).
I believe this is not an error introduced by my changes, rather the problem occurs with the current default scaling as well, if the screen resolution is not divisible by 10, which is the case for most common screen resolutions (`1920x1080` ~> `(192*10)x(108*10)`). Basically, the user has to ensure that the factor is reasonably for his screen resolution.
If the factor is badly chosen for the resolution, the image will either be to large (thus not showing a part of the screenshot) or to small (thus showing a white bar at the right edge of the screen).
You can probably see the bad result if you choose a factor like 0.07.

All in all, I still think my changes provide a valuable contribution because I restricted myself to _adding_ functionality without removing currently working functionality. If you have a proposal how to change my code to work better with the existing code, I'd be happy to do those changes.