### PR TITLE
Replace awk with sed, reduce calls to fc-match

### DIFF
--- a/i3lock-fancy
+++ b/i3lock-fancy
@@ -5,8 +5,11 @@ set -o errexit -o noclobber -o nounset
 
 hue=(-level "0%,100%,0.6")
 effect=(-filter Gaussian -resize 20% -define "filter:sigma=1.5" -resize 500.5%)
+
 # default system sans-serif font
-font=$(convert -list font | awk "{ a[NR] = \$2 } /family: $(fc-match sans -f "%{family}\n")/ { print a[NR-1]; exit }")
+font_name="$(fc-match sans -f "%{family}\n")"
+font=$( convert -list font | sed -n "/^ *Font: /{s/.* //;x};/^ *family: $font_name/{x;p;q}")
+
 image=$(mktemp --suffix=.png)
 shot=(import -window root)
 desktop=""


### PR DESCRIPTION
The prior code was calling spawning a new bash sub-process and invoking an identical call to fc-match for every line being processed by awk. This version calls fc-match only once. It also uses sed, which is more efficient than awk.