### PR TITLE
Remove unnecessary mkdir and rename manpage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,6 @@ BINDIR ?= $(PREFIX)/bin
 
 install:
 	@install -Dm755 i3lock-fancy          -t $(DESTDIR)$(BINDIR)
-	@mkdir   -m755                           $(DESTDIR)$(SHRDIR)/$(PRGM)/icons
 	@install -Dm644 icons/*               -t $(DESTDIR)$(SHRDIR)/$(PRGM)/icons
 	@install -Dm644 doc/i3lock-fancy.1    -t $(DESTDIR)$(SHRDIR)/man/man1
 	@install -Dm644 LICENSE               -t $(DESTDIR)$(SHRDIR)/licenses/$(PRGM)

--- a/doc/i3lock-fancy.1
+++ b/doc/i3lock-fancy.1
@@ -1,7 +1,7 @@
-.TH LOCK 1 2017-06-26
+.TH I3LOCK-FANCY 1 2017-06-26
 
 .SH NAME
-.B lock
+.B i3lock-fancy
 - Bash script around i3lock for fancy effect
 
 .SH DESCRIPTION
@@ -12,7 +12,7 @@ background.
 
 .SH SYNOPSIS
 
-.B lock [options]
+.B i3lock-fancy [options]
 
 .SH OPTIONS
 


### PR DESCRIPTION
install's -D flag will create any necessary parent directories.
Explicitly using mkdir leads to errors in the PKGBUILD because
$pkgdir/usr/share does not exist.