### PR TITLE
Hebrew localization of default text

### DIFF
--- a/i3lock-fancy
+++ b/i3lock-fancy
@@ -51,6 +51,7 @@ case "${LANG:-}" in
     en_* ) text="Type password to unlock" ;; # English
     es_* ) text="Ingrese su contraseña" ;; # Española
     fr_* ) text="Entrez votre mot de passe" ;; # Français
+    he_* ) text="הליענה לטבל המסיס דלקה" ;; # Hebrew עברית (convert doesn't play bidi well)
     id_* ) text="Masukkan kata sandi Anda" ;; # Bahasa Indonesia
     it_* ) text="Inserisci la password" ;; # Italian
     ja_* ) text="パスワードを入力してください" ;; # Japanese


### PR DESCRIPTION
I needed to enter the text backwards for it to appear properly. My guess is that 'convert' doesn't handle bidi well, in which case the same kludge will be necessary for other RTL languages.