### PR TITLE
Add default (empty) target to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,8 @@ PREFIX ?= /usr
 SHRDIR ?= $(PREFIX)/share
 BINDIR ?= $(PREFIX)/bin
 
+all:
+
 install:
 	@install -Dm755 i3lock-fancy          -t $(DESTDIR)$(BINDIR)
 	@install -Dm644 icons/*               -t $(DESTDIR)$(SHRDIR)/$(PRGM)/icons


### PR DESCRIPTION
Previously, running "make" (as opposed to "make install") would attempt to install the utility.