### PR TITLE
Updates afrikaans wording

### DIFF
--- a/i3lock-fancy
+++ b/i3lock-fancy
@@ -46,7 +46,7 @@ eval set -- "$temp"
 # l10n support
 text="Type password to unlock"
 case "${LANG:-}" in
-    af_* ) text="Tipe wagwoord om te ontsluit" ;; # Afrikaans
+    af_* ) text="Tik wagwoord om te ontsluit" ;; # Afrikaans
     de_* ) text="Bitte Passwort eingeben" ;; # Deutsch
     da_* ) text="Indtast adgangskode" ;; # Danish
     en_* ) text="Type password to unlock" ;; # English


### PR DESCRIPTION
The word 'Tik' is the action of typing which makes more sense than 'Tipe' (I don't know if this is actually an afrikaans word.)