### PR TITLE
Speed up PNG compression

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Usage
         -n, --nofork     Do not fork i3lock after starting.
     
         --               Must be last option. Set command to use for taking a
-                         screenshot. Default is 'import -window root'. Using 'scrot'
+                         screenshot. Default is 'import -window root -define png:compression-level=1'. Using 'scrot'
                          or 'maim' will increase script speed and allow setting
                          custom flags like having a delay.
 

--- a/doc/i3lock-fancy.1
+++ b/doc/i3lock-fancy.1
@@ -55,7 +55,7 @@ Do not fork i3lock after starting.
 .TP
 \fB--\fP
 Must be last option. Set command to use for taking a screenshot. Default is
-\'import -window root\'. Using \'scrot\' or \'maim\' will increase script speed and
+\'import -window root -define png:compression-level=1\'. Using \'scrot\' or \'maim\' will increase script speed and
 allow setting custom flags like having a delay.
 
 .SH SEE ALSO

--- a/i3lock-fancy
+++ b/i3lock-fancy
@@ -8,7 +8,7 @@ effect=(-filter Gaussian -resize 20% -define "filter:sigma=1.5" -resize 500.5%)
 # default system sans-serif font
 font=$(convert -list font | awk "{ a[NR] = \$2 } /family: $(fc-match sans -f "%{family}\n")/ { print a[NR-1]; exit }")
 image=$(mktemp --suffix=.png)
-shot=(import -window root)
+shot=(import -window root -define png:compression-level=1)
 desktop=""
 i3lock_cmd=(i3lock -i "$image")
 shot_custom=false
@@ -33,7 +33,7 @@ options="Options:
     -n, --nofork     Do not fork i3lock after starting.
 
     --               Must be last option. Set command to use for taking a
-                     screenshot. Default is 'import -window root'. Using 'scrot'
+                     screenshot. Default is 'import -window root -define png:compression-level=1'. Using 'scrot'
                      or 'maim' will increase script speed and allow setting
                      custom flags like having a delay."
 

--- a/i3lock-fancy
+++ b/i3lock-fancy
@@ -119,7 +119,7 @@ else #black
 fi
 
 convert "$image" "${hue[@]}" "${effect[@]}" -font "$font" -pointsize 26 -fill "$bw" -gravity center \
-    -annotate +0+160 "$text" "$icon" -gravity center -composite "$image"
+    -annotate +0+160 "$text" "$icon" -gravity center -composite -define png:compression-level=1 "$image"
 
 # If invoked with -d/--desktop, we'll attempt to minimize all windows (ie. show
 # the desktop) before locking.


### PR DESCRIPTION
Since the screenshot will only be used for a very small amount of time, it doesn't need to be compressed as well as imagemagick does by default. While this isn't as huge of a speedup compared to #146 , this still halves the time the command takes to execute on my machine without breaking anything and while modifying just a minimal amount of code.