### PR TITLE
Fix i3lock-color command line color options

### DIFF
--- a/i3lock-fancy
+++ b/i3lock-fancy
@@ -105,21 +105,21 @@ color=$(convert "$image" -gravity center -crop 100x100+0+0 +repage -colorspace h
 if [[ $color -gt $value ]]; then #white background image and black text
     bw="black"
     icon="/usr/share/i3lock-fancy/icons/lockdark.png"
-    param=("--insidecolor=0000001c" "--ringcolor=0000003e" \
-        "--linecolor=00000000" "--keyhlcolor=ffffff80" "--ringvercolor=ffffff00" \
-        "--separatorcolor=22222260" "--insidevercolor=ffffff1c" \
-        "--ringwrongcolor=ffffff55" "--insidewrongcolor=ffffff1c" \
-        "--verifcolor=ffffff00" "--wrongcolor=ff000000" "--timecolor=ffffff00" \
-        "--datecolor=ffffff00" "--layoutcolor=ffffff00")
+    param=("--inside-color=0000001c" "--ring-color=0000003e" \
+        "--line-color=00000000" "--keyhl-color=ffffff80" "--ringver-color=ffffff00" \
+        "--separator-color=22222260" "--insidever-color=ffffff1c" \
+        "--ringwrong-color=ffffff55" "--insidewrong-color=ffffff1c" \
+        "--verif-color=ffffff00" "--wrong-color=ff000000" "--time-color=ffffff00" \
+        "--date-color=ffffff00" "--layout-color=ffffff00")
 else #black
     bw="white"
     icon="/usr/share/i3lock-fancy/icons/lock.png"
-    param=("--insidecolor=ffffff1c" "--ringcolor=ffffff3e" \
-        "--linecolor=ffffff00" "--keyhlcolor=00000080" "--ringvercolor=00000000" \
-        "--separatorcolor=22222260" "--insidevercolor=0000001c" \
-        "--ringwrongcolor=00000055" "--insidewrongcolor=0000001c" \
-        "--verifcolor=00000000" "--wrongcolor=ff000000" "--timecolor=00000000" \
-        "--datecolor=00000000" "--layoutcolor=00000000")
+    param=("--inside-color=ffffff1c" "--ring-color=ffffff3e" \
+        "--line-color=ffffff00" "--keyhl-color=00000080" "--ringver-color=00000000" \
+        "--separator-color=22222260" "--insidever-color=0000001c" \
+        "--ringwrong-color=00000055" "--insidewrong-color=0000001c" \
+        "--verif-color=00000000" "--wrong-color=ff000000" "--time-color=00000000" \
+        "--date-color=00000000" "--layout-color=00000000")
 fi
 
 convert "$image" "${hue[@]}" "${effect[@]}" -font "$font" -pointsize 26 -fill "$bw" -gravity center \


### PR DESCRIPTION
i3lock-color changed its color related command line arguments to include an extra dash (e.g. `--inside-color` instead of `--insidecolor`). This causes the script to fall back to i3lock with no color options silently (no error). So, I updated the command line arguments to match the latest release of https://github.com/Raymo111/i3lock-color and the colors work correctly again.