### PR TITLE
refactored 'convert' to 'magick' for IMv7 deprecation

### DIFF
--- a/i3lock-fancy
+++ b/i3lock-fancy
@@ -6,7 +6,7 @@ set -o errexit -o noclobber -o nounset
 hue=(-level "0%,100%,0.6")
 effect=(-filter Gaussian -resize 20% -define "filter:sigma=1.5" -resize 500.5%)
 # default system sans-serif font
-font=$(convert -list font | awk "{ a[NR] = \$2 } /family: $(fc-match sans -f "%{family}\n")/ { print a[NR-1]; exit }")
+font=$(magick -list font | awk "{ a[NR] = \$2 } /family: $(fc-match sans -f "%{family}\n")/ { print a[NR-1]; exit }")
 image=$(mktemp --suffix=.png)
 shot=(import -silent -window root)
 desktop=""
@@ -98,7 +98,7 @@ command -- "${shot[@]}" "$image"
 
 value="60" #brightness value to compare to
 
-color=$(convert "$image" -gravity center -crop 100x100+0+0 +repage -colorspace hsb \
+color=$(magick "$image" -gravity center -crop 100x100+0+0 +repage -colorspace hsb \
     -resize 1x1 txt:- | awk -F '[%$]' 'NR==2{gsub(",",""); printf "%.0f\n", $(NF-1)}');
 
 if [[ $color -gt $value ]]; then #white background image and black text
@@ -121,7 +121,7 @@ else #black
         "--date-color=00000000" "--layout-color=00000000")
 fi
 
-convert "$image" "${hue[@]}" "${effect[@]}" -font "$font" -pointsize 26 -fill "$bw" -gravity center \
+magick "$image" "${hue[@]}" "${effect[@]}" -font "$font" -pointsize 26 -fill "$bw" -gravity center \
     -annotate +0+160 "$text" "$icon" -gravity center -composite "$image"
 
 # If invoked with -d/--desktop, we'll attempt to minimize all windows (ie. show


### PR DESCRIPTION
Just a change to get rid of an error I noticed when playing with this, refactoring the command fixed this.

Previously I noticed this error when running the script manually
```
WARNING: The convert command is deprecated in IMv7, use "magick" instead of "convert" or "magick convert"

WARNING: The convert command is deprecated in IMv7, use "magick" instead of "convert" or "magick convert"

WARNING: The convert command is deprecated in IMv7, use "magick" instead of "convert" or "magick convert"

```